### PR TITLE
Lazily saves user and session in syncclient

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ninja-util",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Helper library to develop Node.JS applications",
   "repository": {
     "type": "git",

--- a/syncclient.js
+++ b/syncclient.js
@@ -59,19 +59,14 @@ function SyncClient(url, authenticator)
 
 SyncClient.prototype.connectToSession = function(user, session)
 {
-	this.user = user;
-	this.session = session;
-
-
-	_sendJoinMessage.call(this);
-
+	_sendJoinMessage.call(this, user, session);
 }
 
-SyncClient.prototype.sendMessage = function(type, data)
+SyncClient.prototype.sendMessage = function(type, data, session = undefined)
 {
 	let message = {
 		type: type,
-		session: this.session,
+		session: this.session || session,
 		data: data
 	};
 
@@ -129,6 +124,9 @@ function _onMessage(event)
 
 	if (type === SyncMessages.JOIN_SUCCESSFUL_MESSAGE)
 	{
+		this.user = message.data.user;
+		this.session = message.session;
+
 		if(!this.sessionState)
 		{
 			this.sessionState = message.data.state;
@@ -169,10 +167,10 @@ function _onMessage(event)
 	}
 }
 
-function _sendJoinMessage()
+function _sendJoinMessage(user, session)
 {
 	this.notify(onSyncJoining);
-	this.sendMessage(SyncMessages.JOIN_MESSAGE, {user: this.user});
+	this.sendMessage(SyncMessages.JOIN_MESSAGE, {user: user}, session);
 }
 
 function _onOpen(event)


### PR DESCRIPTION
This prevents the client to send twice a JOIN message in case one calls `connectToSession()` before the WebSocket connection is open.