### PR TITLE
Fix to injector.js: ignore comments before constructor in injected classes

### DIFF
--- a/injector.js
+++ b/injector.js
@@ -7,7 +7,7 @@
 
 
 const FunctionNameRegex = /\s*function\s*([\w\d_]+)\s*\(([\w\s\,_]*)\)/;
-const ClassNameRegex = /\s*class\s*([\w\d_]+)\s*(extends [\w]*)?\s*\{\s*(constructor\s*\(([\w\s\,_]*)\))?/
+const ClassNameRegex = /\s*class\s*([\w\d_]+)\s*(extends [\w]*)?\s*\{\s*(\/\*[\s\S]*?\*\/|([^\\:]|^)\/\/.*$)?\s*(constructor\s*\(([\w\s\,_]*)\))?/
 
 function Injector()
 {
@@ -115,7 +115,7 @@ Injector.prototype.addResource = function(resource, reference = null, dependenci
 		{
 			functionPart = ClassNameRegex.exec(classStr);
 
-			argumentIdx = 4;
+			argumentIdx = 6;
 		}
 
         if(functionPart && functionPart.length >= 2)


### PR DESCRIPTION
Fixed problem where injector fails to recognize constructor parameters if the constructor is documented.

Used regex material from https://stackoverflow.com/questions/5989315/regex-for-match-replacing-javascript-comments-both-multiline-and-inline