### PR TITLE
change to only upload files in allowed routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ const { ExpressWrapper } = require ('ninja-util');
 
 ```
 
+The wrappers methods for each http method have the `options` parameter, used to send optional settings.
+
+To allow file upload in a specific route, the user should set:
+```js
+options.acceptFiles = true
+```
+
 ## Heap
 
 > TODO

--- a/expresswrapper.js
+++ b/expresswrapper.js
@@ -413,7 +413,7 @@ ExpressWrapper.prototype.put = function(route, streamResponse, callback, options
 		callback = streamResponse;
 		streamResponse = false;
 	}
-	_request.call(this, "put", route, streamResponse, callback, options, options);
+	_request.call(this, "put", route, streamResponse, callback, options);
 };
 
 ExpressWrapper.prototype.delete = function(route, streamResponse, callback, options)

--- a/expresswrapper.js
+++ b/expresswrapper.js
@@ -335,8 +335,8 @@ function _request(method, route, streamResponse, callback, options)
 			try
 			{
 				if (!options || !options.acceptFiles) {
-					if (req.files && req.files.length) {
-						throw "Send files for this route is not allowed";
+					if (req.files && Object.entries(req.files).length) {
+						throw new NHttpError(405, "Sending files to this route is not allowed.");
 					}
 				}
 
@@ -435,7 +435,11 @@ function sendException(res, exp)
 {
 	this.console.trace(`[Exception handled by express wrapper] ${exp}`);
 
-	res.status(500).send("Internal Error");
+	if (exp instanceof NHttpError) {
+		res.status(exp.code).send(exp.payload);
+	} else {
+		res.status(500).send("Internal Error");
+	}
 }
 
 ExpressWrapper.AUTH_NONE        = 1;

--- a/expresswrapper.js
+++ b/expresswrapper.js
@@ -326,19 +326,24 @@ function sendResponse (req, res, err, streamResponse, data, outMimeType = null)
 	}
 }
 
-function _request(method, route, streamResponse, callback)
+function _request(method, route, streamResponse, callback, options)
 {
-	if (method === "post" || method === "put" || method === "delete" || method === "get")
-	{
+	if ( method === "post" || method === "put" || method === "delete" || method === "get")
+	{	
 		this.app[method](route, (req, res) =>
 		{
 			try
 			{
+				if (!options || !options.acceptFiles) {
+					if (req.files && req.files.length) {
+						throw "Send files for this route is not allowed";
+					}
+				}
+
 				this.console.debug(`Route ${req.originalUrl} accessed with method ${method}`);
 				let params = _extractParams.call(this, req);
 
 				this.logRequest (req);
-
 
 				let out = callback(params, (err, data) =>
 				{
@@ -379,7 +384,7 @@ function _request(method, route, streamResponse, callback)
 	}
 };
 
-ExpressWrapper.prototype.get = function(route, streamResponse, callback)
+ExpressWrapper.prototype.get = function(route, streamResponse, callback, options)
 {
 	if (typeof(streamResponse) === 'function')
 	{
@@ -387,10 +392,10 @@ ExpressWrapper.prototype.get = function(route, streamResponse, callback)
 		streamResponse = false;
 	}
 
-	_request.call(this, "get", route, streamResponse, callback);
+	_request.call(this, "get", route, streamResponse, callback, options);
 };
 
-ExpressWrapper.prototype.post = function(route, streamResponse, callback)
+ExpressWrapper.prototype.post = function(route, streamResponse, callback, options)
 {
 	if (typeof(streamResponse) === 'function')
 	{
@@ -398,27 +403,27 @@ ExpressWrapper.prototype.post = function(route, streamResponse, callback)
 		streamResponse = false;
 	}
 
-	_request.call(this, "post", route, streamResponse, callback);
+	_request.call(this, "post", route, streamResponse, callback, options);
 };
 
-ExpressWrapper.prototype.put = function(route, streamResponse, callback)
+ExpressWrapper.prototype.put = function(route, streamResponse, callback, options)
 {
 	if (typeof(streamResponse) === 'function')
 	{
 		callback = streamResponse;
 		streamResponse = false;
 	}
-	_request.call(this, "put", route, streamResponse, callback);
+	_request.call(this, "put", route, streamResponse, callback, options, options);
 };
 
-ExpressWrapper.prototype.delete = function(route, streamResponse, callback)
+ExpressWrapper.prototype.delete = function(route, streamResponse, callback, options)
 {
 	if (typeof(streamResponse) === 'function')
 	{
 		callback = streamResponse;
 		streamResponse = false;
 	}
-	_request.call(this, "delete", route, streamResponse, callback);
+	_request.call(this, "delete", route, streamResponse, callback, options);
 };
 
 ExpressWrapper.prototype.getApp = function()

--- a/expresswrapper.js
+++ b/expresswrapper.js
@@ -334,11 +334,14 @@ function _request(method, route, streamResponse, callback, options)
 		{
 			try
 			{
-				if (!options || !options.acceptFiles) {
-					if (req.files && Object.entries(req.files).length) {
-						throw new NHttpError(405, "Sending files to this route is not allowed.");
-					}
-				}
+				//To block the upload of files through unexpected endpoints uncomment this
+				//Not currently enabled to avoid retrocompatibility issues
+				//Could be included in a future major release
+				//if (!options || !options.acceptFiles) {
+				//	if (req.files && Object.entries(req.files).length) {
+				//		throw new NHttpError(405, "Sending files to this route is not allowed.");
+				//	}
+				//}
 
 				this.console.debug(`Route ${req.originalUrl} accessed with method ${method}`);
 				let params = _extractParams.call(this, req);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "clean-build-ts": "rm -rf types; tsc; ./prepend-copyright-notice-d-ts.sh"
     },
     "dependencies": {
-        "express-fileupload": "^1.3.1",
+        "express-fileupload": "^1.4.0",
         "express-query-boolean": "^2.0.0",
         "jsonwebtoken": "^8.5.1",
         "shortid": "^2.2.14",


### PR DESCRIPTION
Solution to #18 :
-  We now only allow file upload in explicitly allowed routes. 
- To do this, we added a parameter `options` to `ExpressWraper._request` function. 

To allow file upload in a route, `options` should look like `{ acceptFiles: true, ... }`